### PR TITLE
Adding bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,18 @@
+{
+  "name": "Proton",
+  "version": "1.0.0",
+  "homepage": "http://a-jie.github.io/Proton",
+  "authors": [
+    "a-jie <a-jie.cn@msn.com>"
+  ],
+  "description": "Proton is an easily customizable html5 particle engine including five different types of renderers.",
+  "main": "build/proton-1.0.0.min.js",
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
I've also registered git://github.com/a-jie/Proton.git with Bower as "proton" so the package can be installed using:

bower install proton
