### PR TITLE
fix: typo

### DIFF
--- a/src/emitter/Emitter.js
+++ b/src/emitter/Emitter.js
@@ -292,7 +292,7 @@ export default class Emitter extends Particle {
 		}
 
 		if (behaviour) {
-			behaviour = Util.isArray(behaviour) ? behaviour : [behaviour];
+			behaviours = Util.isArray(behaviour) ? behaviour : [behaviour];
 		}
 
 		particle.reset();


### PR DESCRIPTION
Manually creating a particle using Emitter::createParticle incorrectly ignores passed-in behaviors due to a typo.