### PR TITLE
refactor: removeParticle API

### DIFF
--- a/src/emitter/Emitter.js
+++ b/src/emitter/Emitter.js
@@ -113,12 +113,36 @@ export default class Emitter extends Particle {
 	}
 
 	/**
+	 * remove a particle
+	 */
+	removeParticle(particle) {
+		const index = this.particles.indexOf(particle);
+		this.removeParticleAtIndex(index);
+	}
+
+	/**
+	 * remove a particle at specific index
+	 */
+	removeParticleAtIndex(index) {
+		if (index < 0 || index >= this.particles.length) {
+			return;
+		}
+		const particle = this.particles[index];
+		particle.destroy();
+		this.dispatch('PARTICLE_DEAD', particle);
+		this.parent.pool.expire(particle);
+		this.particles.splice(index, 1);
+	}
+
+	/**
 	 * remove current all particles
 	 * @method removeAllParticles
 	 */
 	removeAllParticles() {
 		let i = this.particles.length;
-		while (i--) this.particles[i].dead = true;
+		while (i--) {
+			this.removeParticleAtIndex(i);
+		}
 	}
 
 	/**
@@ -233,10 +257,7 @@ export default class Emitter extends Particle {
 
 			// check dead
 			if (particle.dead) {
-				this.dispatch('PARTICLE_DEAD', particle);
-
-				this.parent.pool.expire(particle);
-				this.particles.splice(i, 1);
+				this.removeParticleAtIndex(i);
 			}
 		}
 	}
@@ -305,7 +326,7 @@ export default class Emitter extends Particle {
 
 	remove() {
 		this.stop();
-		Util.destroy(this.particles);
+		this.removeAllParticles();
 	}
 
 	/**


### PR DESCRIPTION
I need to be able to remove a specific particle from an emitter, so I created two API functions: `removeParticle` which will remove a particle from the emitter and `removeParticleAtIndex` which does the same thing but uses a numeric index (for speed to avoid indexOf calls if possible).

A couple of other light changes to consume the API.